### PR TITLE
Q&A, Stat und Lit mit .env ausgestattet

### DIFF
--- a/src/components/newPublicationCardList.jsx
+++ b/src/components/newPublicationCardList.jsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react'
 import NewPublicationCard from './newPublicationCard'
 
+//Holt jetzt den Host aus der env
+const API_BASE = import.meta.env.VITE_API_BASE_URL
+
 const NewPublicationCardList = () => {
   const [publications, setPublications] = useState([])
 
   useEffect(() => {
     const fetchPublications = async () => {
       try {
-        const response = await fetch('/api/citeref/cards')
+        const response = await fetch('${API_BASE}/api/citeref/cards')
         const data = await response.json()
         setPublications(data)
       } catch (error) {

--- a/src/components/questionAnswer.jsx
+++ b/src/components/questionAnswer.jsx
@@ -1,6 +1,8 @@
 // src/components/QuestionAnswer.jsx
 import React, { useState, useRef } from 'react'
 
+// Produktion oder Entwicklung
+const API_BASE = import.meta.env.VITE_API_BASE_URL
 /**
  * QuestionAnswer Komponente
  *
@@ -59,7 +61,7 @@ const QuestionAnswer = () => {
 
     try {
       // API-Anfrage mit fetch
-      const response = await fetch('/api/ask', {
+      const response = await fetch('${API_BASE}/api/ask', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/statisticsDashboard.jsx
+++ b/src/components/statisticsDashboard.jsx
@@ -1,6 +1,8 @@
 // src/components/statisticsDashboard.jsx - Aktualisierte Version mit Modal-Integration
 import React, { useState, useEffect } from 'react'
 import TopicSummaryModal from './topicSummaryModal' // Importiere die Modal-Komponente
+//Holt jetzt den Host aus der env
+const API_BASE = import.meta.env.VITE_API_BASE_URL
 
 // StatistikDashboard-Komponente mit Hooks für State-Management und Modal-Integration
 const StatistikDashboard = () => {
@@ -31,8 +33,14 @@ const StatistikDashboard = () => {
     try {
       setLoading(true)
 
+      /**
+       *
+       * CAVE: In der Produktion wird der Aufruf 'localhost:5173' (Vite FE) statt localhost:3000 (Backend) versucht
+       *  -> gibt ein Fehler in Chrome. Komischerweise erscheint die Statistik trotzdem
+       *
+       */
       // API-Aufruf zum Backend
-      const response = await fetch('/api/statistics')
+      const response = await fetch('${API_BASE}/api/statistics')
 
       if (!response.ok) {
         throw new Error(`HTTP-Fehler! Status: ${response.status}`)
@@ -44,7 +52,7 @@ const StatistikDashboard = () => {
       // Optional: Dokumente-Anzahl separat laden
       let documentCount = 0
       try {
-        const docResponse = await fetch('/api/documents/count')
+        const docResponse = await fetch('${API_BASE}/api/documents/count')
         const docData = await docResponse.json()
         documentCount = docData.count || 0
       } catch (docError) {


### PR DESCRIPTION
Hab jetzt die Komponenten für die Statistik, Literatur und Q&A bei fetch mit ${API_BASE} ausgestattet